### PR TITLE
Small fixes to compilation/linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 AM_CFLAGS = -Wall -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2
-CFLAGS = -g -O0
+CFLAGS = -g -O0 -pthread
 objects = ctree.o disk-io.o radix-tree.o extent-tree.o print-tree.o \
 	  root-tree.o dir-item.o file-item.o inode-item.o \
 	  inode-map.o crc32c.o rbtree.o extent-cache.o extent_io.o \

--- a/restore.c
+++ b/restore.c
@@ -948,7 +948,7 @@ out:
 		root->fs_info->fs_root =
 			btrfs_read_fs_root_no_cache(root->fs_info, &key);
 		if (IS_ERR(root->fs_info->fs_root)) {
-			fprintf(stderr, "Error reading fs root %d\n",
+			fprintf(stderr, "Error reading fs root %ld\n",
 				PTR_ERR(root->fs_info->fs_root));
 			close_ctree(root);
 			return NULL;


### PR DESCRIPTION
Recent gcc (4.6.1) fails to compile and link due to wrong `fprintf` format specifier for `long int` and due to missing `-pthread` option to the gcc frontend.
